### PR TITLE
fix: set CONFIG_SERIAL_8250* to y and fix typos

### DIFF
--- a/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
+++ b/debian/patches/linux/0002-feat-Radxa-custom-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa custom kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa_custom.config | 93 ++++++++++++++++++++++++++
- 1 file changed, 93 insertions(+)
+ src/arch/arm64/configs/radxa_custom.config | 98 ++++++++++++++++++++++++++
+ 1 file changed, 98 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa_custom.config
 
 diff --git a/src/arch/arm64/configs/radxa_custom.config b/src/arch/arm64/configs/radxa_custom.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..d9550fafb022
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa_custom.config
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,98 @@
 +# Do not create kernel debug package
 +CONFIG_DEBUG_INFO=n
 +
@@ -35,7 +35,7 @@ index 000000000000..d9550fafb022
 +CONFIG_VIDEO_OV7251=y
 +CONFIG_VIDEO_OV13850=y
 +
-+# The following config has security complecations:
++# The following config has security complications:
 +# https://forum.radxa.com/t/lack-of-concern-for-security-in-bsp-kernel/12210
 +# However, this is required for the following issues:
 +# * RK356X MPP hardware video acceleration was not working
@@ -104,6 +104,11 @@ index 000000000000..d9550fafb022
 +CONFIG_SND_SOC_ROCKCHIP=y
 +CONFIG_SND_SOC_ROCKCHIP_I2S=y
 +CONFIG_SND_SOC_ROCKCHIP_I2S_TDM=y
++
++# Fix build error: 'dw8250_do_set_termios' exported twice
++CONFIG_SERIAL_8250=y
++CONFIG_SERIAL_8250_DWLIB=y
++CONFIG_SERIAL_8250_DW=y
 +
 +## Rockchip no longer supports CAN on RK3588 & Linux 6.1 SDK
 +CONFIG_CANFD_ROCKCHIP=n


### PR DESCRIPTION
In the Rockchip kernel, they can only be set to y, otherwise they will be compiled with an error.

Link: https://github.com/radxa-pkg/linux-rk2410-nocsf/pull/3#issuecomment-3166789130